### PR TITLE
Upgrade erlavro from 2.7.1 to 2.8.1

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -7,7 +7,7 @@
            , {d, 'APPLICATION', avlizer}
            , {d, 'NOTEST'}]}.
 
-{deps, [{erlavro, "2.7.1"}]}.
+{deps, [{erlavro, "2.8.1"}]}.
 
 {profiles, [ {test, [{deps, [meck]}]}
            ]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,8 +1,8 @@
 {"1.1.0",
-[{<<"erlavro">>,{pkg,<<"erlavro">>,<<"2.7.1">>},0},
+[{<<"erlavro">>,{pkg,<<"erlavro">>,<<"2.8.1">>},0},
  {<<"jsone">>,{pkg,<<"jsone">>,<<"1.4.6">>},1}]}.
 [
 {pkg_hash,[
- {<<"erlavro">>, <<"37B461C8CB894117B2ADD7B18A0498BF58BB04637733361FF2C86C3FA1970987">>},
+ {<<"erlavro">>, <<"DBA3FBE284EF87512CDC6C893CF3D851F137993B939591B76C8C3CF19950D18D">>},
  {<<"jsone">>, <<"644D6D57BEFB22C8E19B324DEE19D73B1C004565009861A8F64C68B7B9E64DBF">>}]}
 ].

--- a/src/avlizer.app.src
+++ b/src/avlizer.app.src
@@ -1,6 +1,6 @@
 {application, avlizer,
  [{description, "Avro Serializer"},
-  {vsn, "0.3.2"},
+  {vsn, "0.3.3"},
   {registered, []},
   {applications,
    [kernel,


### PR DESCRIPTION
fixes issue in erlavro with parsing props that contains an object as a value.