### PR TITLE
Fetch already published schemas by Subject and Version (or latest)

### DIFF
--- a/test/avlizer_confluent_tests.erl
+++ b/test/avlizer_confluent_tests.erl
@@ -55,6 +55,21 @@ get_encoder_decoder_assign_fp_test_() ->
         42 = avlizer_confluent:decode(Decoder, Bin)
     end).
 
+get_latest_schema_test() ->
+  with_meck(
+    fun() ->
+      {ok, _Id} = avlizer_confluent:register_schema("subj", Schema = test_schema()),
+      {ok, Schema} = avlizer_confluent:get_schema("subj")
+    end).
+
+get_schema_test() ->
+  with_meck(
+    fun() ->
+      {ok, _Id} = avlizer_confluent:register_schema("subj", Schema = test_schema()),
+      {ok, Schema} = avlizer_confluent:get_schema("subj", 1),
+      {ok, Schema} = avlizer_confluent:get_schema("subj", "1")
+    end).
+
 make_encoder_decoder_test_() ->
   with_meck(
     fun() ->
@@ -134,7 +149,7 @@ cleanup(_) ->
 %% make a fake JSON as if downloaded from schema registry
 test_download() ->
   SchemaJSON = test_schema(),
-  jsone:encode(#{<<"schema">> => SchemaJSON}).
+  jsone:encode(#{<<"schema">> => SchemaJSON, <<"id">> => <<"1">>}).
 
 test_schema() ->
   avro:encode_schema(test_type()).


### PR DESCRIPTION
Sometimes there is a need to download an already published schema by Subject and Version.
I didn't add the schemas to the local cache as, as far as I understand, in this use case the user of the library should be the one taking care of how to use the schema.