### PR TITLE
Add support for HTTP Basic Auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,24 @@ Make sure schema registry URL is present in `sys.config` as below
 {avlizer, [{avlizer_confluent, #{schema_registry_url => URL}}]}
 ```
 
-Or set os env variable: `AVLIZER_CONFLUENT_SCHEMAREGISTRY_URL`
+Or set os env variable: 
 
+`AVLIZER_CONFLUENT_SCHEMAREGISTRY_URL`
+
+### Authentication support
+avlizer currently supports `Basic` authentication mechanism, to use it make sure `schema_registry_auth` tuple `{Mechanism, File}`, is present in `sys.config`, where File is the path to a text file which contains two lines, first line for username and second line for password
+
+```
+{avlizer, [{avlizer_confluent, #{
+    schema_registry_url => URL, 
+    schema_registry_auth => {basic, File}}
+}]}
+```
+
+Or set authorization env variables:
+
+`AVLIZER_CONFLUENT_SCHEMAREGISTRY_AUTH_MECHANISM`
+
+`AVLIZER_CONFLUENT_SCHEMAREGISTRY_AUTH_USERNAME`
+
+`AVLIZER_CONFLUENT_SCHEMAREGISTRY_AUTH_PASSWORD`

--- a/priv/auth_test.txt
+++ b/priv/auth_test.txt
@@ -1,0 +1,2 @@
+avlizer_username
+avlizer_password

--- a/src/avlizer.app.src
+++ b/src/avlizer.app.src
@@ -1,6 +1,6 @@
 {application, avlizer,
  [{description, "Avro Serializer"},
-  {vsn, "0.3.4"},
+  {vsn, "0.4.0"},
   {registered, []},
   {applications,
    [kernel,

--- a/src/avlizer.erl
+++ b/src/avlizer.erl
@@ -25,16 +25,71 @@
         ]).
 
 start(_StartType, _StartArgs) ->
-  case osenv("AVLIZER_CONFLUENT_SCHEMAREGISTRY_URL", false) of
-    false -> ok;
-    URL ->
-      Vars0 = application:get_env(?APPLICATION, avlizer_confluent, #{}),
-      Vars = Vars0#{schema_registry_url => URL},
-      application:set_env(?APPLICATION, avlizer_confluent, Vars)
-  end,
+  set_envs(),
   avlizer_sup:start_link().
 
 stop(_State) -> ok.
+
+set_envs() ->
+  Vars0 = application:get_env(?APPLICATION, avlizer_confluent, #{}),
+  Vars1 = maybe_put_schema_registry_url(Vars0),
+  Vars2 = maybe_put_schema_registry_auth(Vars1),
+  application:set_env(?APPLICATION, avlizer_confluent, Vars2).
+
+maybe_put_schema_registry_url(Map) ->
+  SchemaRegistryURL = osenv("AVLIZER_CONFLUENT_SCHEMAREGISTRY_URL", false),
+  case SchemaRegistryURL of
+    false -> Map;
+    URL -> maps:put(schema_registry_url, URL, Map)
+  end.
+
+maybe_put_schema_registry_auth(Map) ->
+  case osenv_all([
+   "AVLIZER_CONFLUENT_SCHEMAREGISTRY_AUTH_MECHANISM",
+   "AVLIZER_CONFLUENT_SCHEMAREGISTRY_AUTH_USERNAME",
+   "AVLIZER_CONFLUENT_SCHEMAREGISTRY_AUTH_PASSWORD"
+  ], false) of
+    [Mechanism, Username, Password] -> 
+      maps:put(schema_registry_auth, {list_to_atom(Mechanism), Username, Password}, Map);
+    false -> 
+      maybe_read_auth_file(Map)
+  end.
+
+maybe_read_auth_file(#{schema_registry_auth := {_Mechanism, File}} = Vars) ->
+  case file:read_file(File) of
+    {ok, Binary} -> maybe_read_auth_file(Vars, Binary);
+    Error -> Error
+  end;
+maybe_read_auth_file(Vars) -> Vars.
+
+maybe_read_auth_file(#{schema_registry_auth := {Mechanism, File}} = Vars, Binary) ->
+  Lines = binary:split(Binary, <<"\n">>, [trim_all, global]),
+  case Lines of
+    [Username, Password] -> 
+      Auth = {Mechanism, binary_to_list(Username), binary_to_list(Password)},
+      maps:put(schema_registry_auth, Auth, Vars);
+    _Malformed -> 
+      error_logger:error_msg("Malformed authorization file ~s", [File]),
+      Vars
+  end.
+
+osenv_all(Names, Default) ->
+  {Values, Unset} = lists:foldr(fun (Name, {Values, Unset}) -> 
+    case osenv(Name, false) of
+      false -> {Values, [Name | Unset]};
+      Value -> {[Value | Values], Unset}
+    end
+  end, {[], []}, Names),
+
+  case length(Unset) of
+    0 -> 
+      Values;
+    UnsetLength when UnsetLength == length(Names) -> 
+      Default;
+    _UnsetLength -> 
+      error_logger:error_msg("Some environment variables aren't set: ~p", [Unset]),
+      Default
+  end.
 
 osenv(Name, Default) ->
   case os:getenv(Name) of


### PR DESCRIPTION
Hi, @k32 ,

The feature I have implemented is a [HTTP Basic Auth to connect into the Confluent Cloud](https://docs.confluent.io/current/security/basic-auth.html), implement the SASL authentication mechanism is a bit more complicated, and maybe in the future, I will give it a try. I have closed the last PR since I named the auth mechanism wrong and opened this instead. Sorry for the confusion and thanks for your patience.