### PR TITLE
Allow passing codec options to decoder

### DIFF
--- a/src/avlizer_confluent.erl
+++ b/src/avlizer_confluent.erl
@@ -133,7 +133,8 @@ stop() ->
 make_decoder(Ref) ->
   do_make_decoder(Ref, ?DEFAULT_CODEC_OPTIONS).
 
--spec make_decoder(name(), fp() | codec_options()) -> avro:simple_decoder().
+-spec make_decoder(ref(), codec_options()) -> avro:simple_decoder();
+                  (name(), fp()) -> avro:simple_decoder().
 make_decoder(Ref, CodecOptions) when ?IS_REF(Ref) ->
   do_make_decoder(Ref, CodecOptions);
 make_decoder(Name, Fp) ->
@@ -277,10 +278,10 @@ untag_data(<<?VSN:8, RegId:32/unsigned-integer, Body/binary>>) ->
 %% @doc Decode tagged payload
 -spec decode(binary()) -> avro:out().
 decode(Bin) ->
-  {RegId, Payload} = untag_data(Bin),
-  decode(RegId, Payload).
+  decode(Bin, ?DEFAULT_CODEC_OPTIONS).
 
 %% @doc Decode untagged payload or with a given schema reference.
+%% Decode tagged payload with custom codec options
 -spec decode(binary(), codec_options()) -> avro:out();
             (ref(), binary()) -> avro:out();
             (avro:simple_decoder(), binary()) -> avro:out().
@@ -293,6 +294,7 @@ decode(Decoder, Bin) when is_function(Decoder) ->
   Decoder(Bin).
 
 %% @doc Decode avro binary with given schema name and fingerprint.
+%% decode avro binary with given schema reference and custom codec options
 -spec decode(name(), fp(), binary()) -> avro:out();
       (ref(), binary(), codec_options()) -> avro:out().
 decode(Ref, Bin, CodecOptions) when is_list(CodecOptions) ->

--- a/src/avlizer_confluent.erl
+++ b/src/avlizer_confluent.erl
@@ -99,7 +99,7 @@
 -define(IS_REF(Ref), (?IS_REGID(Ref) orelse ?IS_NAME_FP(Ref))).
 -type regid() :: non_neg_integer().
 -type name() :: string() | binary().
--type fp() :: avro:crc64_fingerprint() | binary().
+-type fp() :: avro:crc64_fingerprint() | binary() | string().
 -type ref() :: regid() | {name(), fp()}.
 -type codec_options() :: avro:codec_options().
 
@@ -134,7 +134,7 @@ make_decoder(Ref) ->
   do_make_decoder(Ref, ?DEFAULT_CODEC_OPTIONS).
 
 -spec make_decoder(name(), fp() | codec_options()) -> avro:simple_decoder().
-make_decoder(Ref, CodecOptions) when is_list(CodecOptions) ->
+make_decoder(Ref, CodecOptions) when ?IS_REF(Ref) ->
   do_make_decoder(Ref, CodecOptions);
 make_decoder(Name, Fp) ->
   do_make_decoder({Name, Fp}, ?DEFAULT_CODEC_OPTIONS).
@@ -175,7 +175,7 @@ get_decoder(Ref) ->
 
 -spec get_decoder(ref(), codec_options()) -> avro:simple_decoder();
                  (name(), fp()) -> avro:simple_decoder().
-get_decoder(Ref, CodecOptions) when is_list(CodecOptions) ->
+get_decoder(Ref, CodecOptions) when ?IS_REF(Ref) ->
   do_get_decoder(Ref, CodecOptions);
 get_decoder(Name, Fp) -> get_decoder({Name, Fp}).
 

--- a/src/avlizer_confluent.erl
+++ b/src/avlizer_confluent.erl
@@ -168,7 +168,7 @@ make_encoder(Name, Fp) -> make_encoder({Name, Fp}).
 %% @doc Get avro decoder by lookup already decoded avro schema
 %% from cache, and make a decoder from it.
 %% Schema lookup is performed inside the decoder function for each call,
-%% use `make_enodcer/1' for better performance.
+%% use `make_encoder/1' for better performance.
 -spec get_decoder(ref()) -> avro:simple_decoder().
 get_decoder(Ref) ->
   do_get_decoder(Ref, ?DEFAULT_CODEC_OPTIONS).
@@ -190,7 +190,7 @@ do_get_decoder(Ref, CodecOptions) ->
 %% @doc Get avro decoder by lookup already decode avro schema
 %% from cache, and make a encoder from it.
 %% Schema lookup is performed inside the encoder function for each call,
-%% use `make_enodcer/1' for better performance.
+%% use `make_encoder/1' for better performance.
 -spec get_encoder(ref()) -> avro:simple_encoder().
 get_encoder(Ref) ->
   Encoder = avro:make_encoder(?LKUP(Ref), [{encoding, avro_binary}]),

--- a/src/avlizer_confluent.erl
+++ b/src/avlizer_confluent.erl
@@ -281,7 +281,7 @@ decode(Bin) ->
   decode(Bin, ?DEFAULT_CODEC_OPTIONS).
 
 %% @doc Decode untagged payload or with a given schema reference.
-%% Decode tagged payload with custom codec options
+%% Decode tagged payload with custom codec options.
 -spec decode(binary(), codec_options()) -> avro:out();
             (ref(), binary()) -> avro:out();
             (avro:simple_decoder(), binary()) -> avro:out().
@@ -294,7 +294,7 @@ decode(Decoder, Bin) when is_function(Decoder) ->
   Decoder(Bin).
 
 %% @doc Decode avro binary with given schema name and fingerprint.
-%% decode avro binary with given schema reference and custom codec options
+%% Decode avro binary with given schema reference and custom codec options.
 -spec decode(name(), fp(), binary()) -> avro:out();
       (ref(), binary(), codec_options()) -> avro:out().
 decode(Ref, Bin, CodecOptions) when is_list(CodecOptions) ->

--- a/test/avlizer_confluent_tests.erl
+++ b/test/avlizer_confluent_tests.erl
@@ -74,7 +74,7 @@ make_encoder_decoder_with_fp_test_() ->
   with_meck(
     fun() ->
         Name = <<"name-4">>,
-        Fp = <<"md5-hex">>,
+        Fp = "md5-hex",
         Sc = test_schema(),
         ok = avlizer_confluent:register_schema_with_fp(Name, Fp, Sc),
         Encoder = avlizer_confluent:make_encoder(Name, Fp),


### PR DESCRIPTION
Link to the issue: #16 
The API should not have been changed as a result of this change apart from one side-effect: the library will no longer support string fingerprints in `avlizer_confluent:make_decoder/2` (because strings will pattern match as lists and be treated like codec_options). I would emphasize that the use of strings there was against the type spec.

UPD: string fp support has been re-enabled